### PR TITLE
Improve sample pack storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "YouTube Beatmaker Extension",
   "version": "1.1",
   "description": "Mark cue points, play drum sounds, and customize your experience on YouTube.",
-  "permissions": ["storage", "activeTab", "scripting"],
+  "permissions": ["storage", "activeTab", "scripting", "unlimitedStorage"],
   "host_permissions": ["https://www.youtube.com/*"],
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
## Summary
- leverage `chrome.storage.local` for sample pack persistence
- request `unlimitedStorage` permission
- load sample packs asynchronously during initialization

## Testing
- `bash build_release.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840a0e44e448327b7097870d62e32fe