### PR TITLE
Support Samplette.io and update to v1.2 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Update 1.1
+# Update 1.2 Beta
 Mark cue points, play drum sounds, and customize your experience on YouTube.
 The extension supports managing multiple sample packs at once. Use the multi-
 select dropdown in the advanced panel to load several packs together or delete
@@ -17,6 +17,11 @@ https://www.instagram.com/reel/DKfAljPMP5w/?igsh=MXUzZG05ajg2dzJsMA==
 Mark cue points, loop audio/video, apply live effects, and customize your beatmaking experience on YouTube.
 
 The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, audio and video looping, effects toggling, and intuitive cue management. Use keyboard shortcuts or the detailed Advanced Panel for quick control.
+
+## New in 1.2 Beta
+* Works inside the embedded YouTube player on [Samplette.io](https://samplette.io)
+* Minimal bar and advanced window become scrollable when space is limited
+* MIDI control is disabled on Samplette to avoid permission prompts
 
 Manage multiple compressors (Native, Tape Warm, Roland SP404OG) to shape your audio character. Adjust settings effortlessly through a user-friendly interface.
 

--- a/content.js
+++ b/content.js
@@ -126,6 +126,13 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
   let cleanupFunctions = [];
   let tapTimes = [];
   let padIndicators = [];
+  const isSampletteEmbed = document.referrer.includes('samplette.io');
+  function shouldRunOnThisPage() {
+    if (window.location.hostname === 'samplette.io' && window === window.top) {
+      return false;
+    }
+    return true;
+  }
   /**************************************
    * Global Variables
    **************************************/
@@ -6173,6 +6180,8 @@ function injectCustomCSS() {
       border-radius: 6px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.4);
       width: 210px;
+      max-height: 70vh;
+      overflow-y: auto;
     }
     .looper-drag-handle {
       background: #222;
@@ -6212,6 +6221,7 @@ function injectCustomCSS() {
       justify-content: flex-end;
       gap: 6px;
       margin-right: 6px;
+      overflow-x: auto;
     }
     .ytbm-minimal-bar .looper-btn {
       background: #333;
@@ -6369,6 +6379,7 @@ attachVideoMetadataListener();
  **************************************/
 async function initialize() {
   try {
+    if (!shouldRunOnThisPage()) return;
     let isAudioPrimed = false;
 
     document.addEventListener('click', function primeAudio() {
@@ -6395,7 +6406,9 @@ async function initialize() {
       activeSamplePackNames = [currentSamplePackName];
       await applySelectedSamplePacks();
     }
-    initializeMIDI();
+    if (!isSampletteEmbed) {
+      initializeMIDI();
+    }
     addControls();
     buildMinimalUIBar();
     addTouchButtonToMinimalUI();

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,23 @@
 {
   "manifest_version": 3,
   "name": "YouTube Beatmaker Extension",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Mark cue points, play drum sounds, and customize your experience on YouTube.",
   "permissions": ["storage", "activeTab", "scripting", "unlimitedStorage"],
-  "host_permissions": ["https://www.youtube.com/*"],
+  "host_permissions": [
+    "https://www.youtube.com/*",
+    "https://samplette.io/*"
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": "icon.png"
   },
   "content_scripts": [
     {
-      "matches": ["https://www.youtube.com/*"],
+      "matches": [
+        "https://www.youtube.com/*",
+        "https://samplette.io/*"
+      ],
       "js": ["content.js"],
       "css": ["style.css"]
     }


### PR DESCRIPTION
## Summary
- update extension version to **1.2**
- allow running on Samplette.io
- add `shouldRunOnThisPage()` check and disable MIDI when embedded in Samplette
- make advanced panel and minimal bar scrollable
- document new behaviour in README

## Testing
- `bash build_release.sh`

------
https://chatgpt.com/codex/tasks/task_e_68437df2d8148327b7ab66873c42d661