### PR TITLE
Support Samplette iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, aud
 * Minimal bar and advanced window become scrollable when space is limited
 * Route audio to any available output device via the **Audio Out** dropdown ("Default output" preselected)
 * Choose your microphone via the **Audio In** dropdown ("Default input" preselected)
-* Pick a dedicated monitoring source in the **Monitor In** dropdown. Selecting a device plays it through your system speakers; choose "Default monitoring input off" to disable it.
+* Pick a dedicated monitoring source in the **Monitor In** dropdown. Selecting a device plays it through your system speakers; choose "Default monitoring input off" to disable it. Monitoring is independent of the mic button.
 * Output routing adjusts automatically when selecting a new device
 * Avoids duplicate initialization in YouTube iframes to prevent freezes
 * Mic button cycles through Off → Record (green) → Monitor (red) so you can hear your input while capturing loops or video

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Update 1.1
+# Update 1.2 Beta
 Mark cue points, play drum sounds, and customize your experience on YouTube.
 The extension supports managing multiple sample packs at once. Use the multi-
 select dropdown in the advanced panel to load several packs together or delete
@@ -17,6 +17,16 @@ https://www.instagram.com/reel/DKfAljPMP5w/?igsh=MXUzZG05ajg2dzJsMA==
 Mark cue points, loop audio/video, apply live effects, and customize your beatmaking experience on YouTube.
 
 The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, audio and video looping, effects toggling, and intuitive cue management. Use keyboard shortcuts or the detailed Advanced Panel for quick control.
+
+## New in 1.2 Beta
+* Works inside the embedded YouTube player on [Samplette.io](https://samplette.io)
+* Minimal bar and advanced window become scrollable when space is limited
+* MIDI control is disabled on Samplette to avoid permission prompts
+* Route audio to any available output device via the **Audio Out** dropdown ("Default output" preselected)
+* Choose your microphone via the **Audio In** dropdown ("Default input" preselected)
+* Pick a dedicated monitoring source in the **Monitor In** dropdown. Selecting a device plays it through your system speakers; choose "Default monitoring input off" to disable it.
+* Lower latency when changing outputs thanks to native `AudioContext.setSinkId` support
+* Mic button cycles through Off → Record (green) → Monitor (red) so you can hear your input while capturing loops or video
 
 Manage multiple compressors (Native, Tape Warm, Roland SP404OG) to shape your audio character. Adjust settings effortlessly through a user-friendly interface.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, aud
 * Choose your microphone via the **Audio In** dropdown ("Default input" preselected)
 * Pick a dedicated monitoring source in the **Monitor In** dropdown. Selecting a device plays it through your system speakers; choose "Default monitoring input off" to disable it.
 * Lower latency when changing outputs thanks to native `AudioContext.setSinkId` support
+* Avoids duplicate initialization in YouTube iframes to prevent freezes
 * Mic button cycles through Off → Record (green) → Monitor (red) so you can hear your input while capturing loops or video
 
 Manage multiple compressors (Native, Tape Warm, Roland SP404OG) to shape your audio character. Adjust settings effortlessly through a user-friendly interface.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Mark cue points, loop audio/video, apply live effects, and customize your beatma
 The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, audio and video looping, effects toggling, and intuitive cue management. Use keyboard shortcuts or the detailed Advanced Panel for quick control.
 
 ## New in 1.2 Beta
-* Works inside the embedded YouTube player on [Samplette.io](https://samplette.io) and other `youtube-nocookie.com` embeds
+* Works inside the YouTube iframe on [Samplette.io](https://samplette.io) and other `youtube-nocookie.com` embeds. The toolbar becomes scrollable and MIDI features are disabled there.
 * Minimal bar and advanced window become scrollable when space is limited
-* MIDI control is disabled on Samplette to avoid permission prompts
 * Route audio to any available output device via the **Audio Out** dropdown ("Default output" preselected)
 * Choose your microphone via the **Audio In** dropdown ("Default input" preselected)
 * Pick a dedicated monitoring source in the **Monitor In** dropdown. Selecting a device plays it through your system speakers; choose "Default monitoring input off" to disable it.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, aud
 * Route audio to any available output device via the **Audio Out** dropdown ("Default output" preselected)
 * Choose your microphone via the **Audio In** dropdown ("Default input" preselected)
 * Pick a dedicated monitoring source in the **Monitor In** dropdown. Selecting a device plays it through your system speakers; choose "Default monitoring input off" to disable it.
-* Lower latency when changing outputs thanks to native `AudioContext.setSinkId` support
+* Output routing adjusts automatically when selecting a new device
 * Avoids duplicate initialization in YouTube iframes to prevent freezes
 * Mic button cycles through Off → Record (green) → Monitor (red) so you can hear your input while capturing loops or video
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Mark cue points, loop audio/video, apply live effects, and customize your beatma
 The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, audio and video looping, effects toggling, and intuitive cue management. Use keyboard shortcuts or the detailed Advanced Panel for quick control.
 
 ## New in 1.2 Beta
-* Works inside the embedded YouTube player on [Samplette.io](https://samplette.io)
+* Works inside the embedded YouTube player on [Samplette.io](https://samplette.io) and other `youtube-nocookie.com` embeds
 * Minimal bar and advanced window become scrollable when space is limited
 * MIDI control is disabled on Samplette to avoid permission prompts
 * Route audio to any available output device via the **Audio Out** dropdown ("Default output" preselected)

--- a/content.js
+++ b/content.js
@@ -342,16 +342,18 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
       if (monitorMicDeviceId !== 'default') {
         mc.audio = { deviceId: { exact: monitorMicDeviceId } };
       }
-      monitorStream = await navigator.mediaDevices.getUserMedia(mc);
-      monitorOutputAudio = new Audio();
-      monitorOutputAudio.autoplay = true;
-      monitorOutputAudio.style.display = 'none';
-      document.body.appendChild(monitorOutputAudio);
-      monitorOutputAudio.srcObject = monitorStream;
-      if (monitorOutputAudio.setSinkId) {
-        try { await monitorOutputAudio.setSinkId(''); } catch {}
+      const stream = await navigator.mediaDevices.getUserMedia(mc);
+      const audioEl = document.createElement('audio');
+      audioEl.autoplay = true;
+      audioEl.style.display = 'none';
+      if (document.body) document.body.appendChild(audioEl);
+      audioEl.srcObject = stream;
+      if (audioEl.setSinkId) {
+        try { await audioEl.setSinkId(''); } catch {}
       }
-      monitorOutputAudio.play().catch(() => {});
+      await audioEl.play().catch(() => {});
+      monitorStream = stream;
+      monitorOutputAudio = audioEl;
       monitoringActive = true;
     } catch (err) {
       console.warn('monitor input error', err);

--- a/content.js
+++ b/content.js
@@ -715,11 +715,10 @@ async function toggleMicInput() {
       alert('Could not access microphone: ' + err.message);
     }
   } else if (micState === 1) {
-    // STATE 1 → 2: Enable monitoring and route to output/video
+    // STATE 1 → 2: Route mic to output/video
     if (micGainNode) {
       micGainNode.connect(bus4Gain);
     }
-    applyMonitorSelection();
     micState = 2;
   } else {
     // STATE 2 → 0: Turn mic completely off

--- a/content.js
+++ b/content.js
@@ -128,8 +128,16 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
   let padIndicators = [];
   const isSampletteEmbed = document.referrer.includes('samplette.io');
   function shouldRunOnThisPage() {
-    if (window.location.hostname === 'samplette.io' && window === window.top) {
+    const host = window.location.hostname;
+    if (host === 'samplette.io' && window === window.top) {
+      // Skip the outer Samplette page but run inside the YouTube iframe
       return false;
+    }
+    if (host.includes('youtube.com')) {
+      // Avoid duplicate initialization inside miscellaneous YouTube iframes
+      if (window !== window.top && !isSampletteEmbed) {
+        return false;
+      }
     }
     return true;
   }

--- a/content.js
+++ b/content.js
@@ -133,7 +133,7 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
       // Skip the outer Samplette page but run inside the YouTube iframe
       return false;
     }
-    if (host.includes('youtube.com')) {
+    if (host.includes('youtube.com') || host.includes('youtube-nocookie.com')) {
       // Avoid duplicate initialization inside miscellaneous YouTube iframes
       if (window !== window.top && !isSampletteEmbed) {
         return false;

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,24 @@
 {
   "manifest_version": 3,
   "name": "YouTube Beatmaker Extension",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Mark cue points, play drum sounds, and customize your experience on YouTube.",
   "permissions": ["storage", "activeTab", "scripting", "unlimitedStorage"],
-  "host_permissions": ["https://www.youtube.com/*"],
+  "host_permissions": [
+    "https://www.youtube.com/*",
+    "https://samplette.io/*"
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": "icon.png"
   },
   "content_scripts": [
     {
-      "matches": ["https://www.youtube.com/*"],
+      "matches": [
+        "https://www.youtube.com/*",
+        "https://samplette.io/*"
+      ],
+      "all_frames": true,
       "js": ["content.js"],
       "css": ["style.css"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "permissions": ["storage", "activeTab", "scripting", "unlimitedStorage"],
   "host_permissions": [
     "https://www.youtube.com/*",
+    "https://www.youtube-nocookie.com/*",
     "https://samplette.io/*"
   ],
   "action": {
@@ -16,6 +17,7 @@
     {
       "matches": [
         "https://www.youtube.com/*",
+        "https://www.youtube-nocookie.com/*",
         "https://samplette.io/*"
       ],
       "all_frames": true,

--- a/options.html
+++ b/options.html
@@ -6,14 +6,20 @@
 </head>
 <body>
   <h3>Customize Drum Keys</h3>
-  <p>Kick (Keyboard): <input id="kickKey" type="text" maxlength="1" /></p>
-  <p>Hi-Hat (Keyboard): <input id="hihatKey" type="text" maxlength="1" /></p>
-  <p>Snare (Keyboard): <input id="snareKey" type="text" maxlength="1" /></p>
+  <p><label for="kickKey">Kick (Keyboard):</label>
+     <input id="kickKey" name="kickKey" type="text" maxlength="1" /></p>
+  <p><label for="hihatKey">Hi-Hat (Keyboard):</label>
+     <input id="hihatKey" name="hihatKey" type="text" maxlength="1" /></p>
+  <p><label for="snareKey">Snare (Keyboard):</label>
+     <input id="snareKey" name="snareKey" type="text" maxlength="1" /></p>
 
   <h3>Customize MIDI Notes</h3>
-  <p>Kick (MIDI): <input id="kickNote" type="number" /></p>
-  <p>Hi-Hat (MIDI): <input id="hihatNote" type="number" /></p>
-  <p>Snare (MIDI): <input id="snareNote" type="number" /></p>
+  <p><label for="kickNote">Kick (MIDI):</label>
+     <input id="kickNote" name="kickNote" type="number" /></p>
+  <p><label for="hihatNote">Hi-Hat (MIDI):</label>
+     <input id="hihatNote" name="hihatNote" type="number" /></p>
+  <p><label for="snareNote">Snare (MIDI):</label>
+     <input id="snareNote" name="snareNote" type="number" /></p>
 
   <button id="saveSettings">Save Settings</button>
 </body>


### PR DESCRIPTION
## Summary
- run content script in all frames so it loads inside Samplette's embedded player
- disable MIDI initialization and hooks when running inside Samplette
- add dropdown for selecting the audio output device
- add dropdown for microphone input device and remember selection
- guard crossfade when no decks and make UI scrollable
- route audio through a hidden element so output device changes work
- provide "Default output" and "Default input" options automatically
- use AudioContext.setSinkId when available to reduce latency
- skip MIDI hook on Samplette's homepage
- guard EQ node access during undo/redo
- fix EQ window crash before audio init
- add dropdown for monitoring input devices with green highlight when active
- monitor input signal plays on default speakers without affecting extension audio
- add monitoring off option and update docs
- decouple monitor input from mic so selecting a monitor device immediately plays through system speakers
- **restore three-state mic button so you can record silently, then monitor and capture to video**

## Testing
- `bash build_release.sh`


------
https://chatgpt.com/codex/tasks/task_e_68437df2d8148327b7ab66873c42d661