### PR TITLE
Fix MIDI doubling effect

### DIFF
--- a/content.js
+++ b/content.js
@@ -605,6 +605,9 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
       isModPressed = false,
       pitchDownInterval = null,
       pitchUpInterval = null,
+      // Track last processed MIDI message to filter duplicates
+      lastMidiTimestamp = 0,
+      lastMidiData = [],
       // 4-Bus Audio nodes
       audioContext = null,
       videoGain = null,
@@ -5560,6 +5563,16 @@ async function initializeMIDI() {
 }
 
 function handleMIDIMessage(e) {
+  // Filter out duplicate events which can happen on some controllers
+  if (e.timeStamp === lastMidiTimestamp &&
+      e.data[0] === lastMidiData[0] &&
+      e.data[1] === lastMidiData[1] &&
+      e.data[2] === lastMidiData[2]) {
+    return;
+  }
+  lastMidiTimestamp = e.timeStamp;
+  lastMidiData = [...e.data];
+
   let [st, note] = e.data;
   if (note === midiNotes.shift) {
     if (st === 144) isModPressed = true;

--- a/content.js
+++ b/content.js
@@ -1448,6 +1448,8 @@ hideYouTubePopups();
     navigator.requestMIDIAccess().then(access => {
       function hook(port) {
         if (!port || port.type !== 'input') return;
+        if (port._ytbmHooked) return; // avoid duplicate wrappers
+        port._ytbmHooked = true;
         const orig = port.onmidimessage;
         port.onmidimessage = function(ev) {
           if (unhideOnInput) pulseShowYTControls();


### PR DESCRIPTION
## Summary
- patch MIDI hook to skip adding duplicate wrappers when devices reconnect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486a2746a883278d4ff4c17348747c