### PR TITLE
Add multi-audio looping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   additional loops stay synced to that BPM. Double press a loop key to erase.
   Exporting downloads each loop with its BPM in the file name. Use `V` for the
   video looper.
-  Press `P` to pause or resume all loops.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -104,7 +103,6 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Reverb Toggle | Q |
 | Cassette Toggle | W |
 | Undo / Redo | U / Cmd+U |
-| Pause Loops | P |
 | Export | Ctrl/Cmd + Enter |
 | Pitch Down / Up | `,` / `.` |
 | Random Cue | `-` |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
   up to four separate audio loops. The first loop sets the tempo automatically;
   additional loops stay synced to that BPM. Recording a new loop while others
-  play adds it seamlessly without restarting. Loops keep the exact length you
+  play adds it seamlessly without restarting. Press another loop key during
+  playback to queue a new recording for the next bar. Loops keep the exact length you
   recorded—automatic trimming has been removed to avoid cutting short sounds.
   Double press a loop key to stop the loops after the current bar finishes. Hold
   that second press a moment longer (or tap three times quickly) to erase the

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   loop with its BPM in the file name. Use `V` for the video looper. Hold Option
   and press **Cmd+R** to erase **all** loops. Use Cmd+R/S/D/F individually to
   erase loops A–D or Cmd+V for the video loop. Each looper button now has a
-  compact progress bar tucked beneath it with four tick marks showing the current
-  bar, and the button itself pulses in time while recording. Hold the mapped
-  **MIDI Shift** note while pressing any loop note to erase that loop instantly.
+compact progress bar tucked beneath it with four tick marks showing the current
+bar, and the button itself pulses in time while recording. Progress fills use
+bright CMYK colors (cyan, magenta, yellow, black) so each loop stands out.
+Hold the mapped **MIDI Shift** note while pressing any loop note to erase that
+loop instantly.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   selected loop—the button blinks briefly when this happens. Loops can be
   resumed individually with a single press; if no loops are playing they start
   immediately, otherwise they wait for the next bar. Exporting downloads each
-  loop with its BPM in the file name. Use `V` for the video looper.
+  loop with its BPM in the file name. Use `V` for the video looper. Press
+  **Cmd+R** any time to erase all audio loops at once.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -110,6 +111,7 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Reverb Toggle | Q |
 | Cassette Toggle | W |
 | Undo / Redo | U / Cmd+U |
+| Erase All Loops | Cmd+R |
 | Export | Ctrl/Cmd + Enter |
 | Pitch Down / Up | `,` / `.` |
 | Random Cue | `-` |

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   up to four separate audio loops. The first loop sets the tempo automatically;
   additional loops stay synced to that BPM. Double press a loop key to stop the
   loops after the current bar finishes. Hold that second press a moment longer
-  (or tap three times quickly) to erase the selected loop. Single pressing while
-  stopped resumes playback on the next bar. Exporting downloads each loop with
+  (or tap three times quickly) to erase the selected loop—the button blinks
+  briefly when this happens. If no loops are currently playing, new recordings
+  start immediately; otherwise they wait for the next bar. Single presses while
+  stopped resume playback on the next bar. Exporting downloads each loop with
   its BPM in the file name. Use `V` for the video looper.
 
 - 🎚️ **Pitch Control**  

--- a/README.md
+++ b/README.md
@@ -57,13 +57,12 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   play adds it seamlessly without restarting. Press another loop key during
   playback to queue a new recording for the next bar. Loops keep the exact length you
   recorded—automatic trimming has been removed to avoid cutting short sounds.
-  Double press a loop key to stop the loops after the current bar finishes. Hold
-  that second press a moment longer (or tap three times quickly) to erase the
-  selected loop—the button blinks briefly when this happens. If no loops are
-  currently playing, new recordings start immediately; otherwise they wait for
-  the next bar. Single presses while stopped resume playback on the next bar.
-  Exporting downloads each loop with its BPM in the file name. Use `V` for the
-  video looper.
+  Double press a loop key to stop **that** loop at the end of the bar. Hold the
+  second press a moment longer (or tap three times quickly) to erase only the
+  selected loop—the button blinks briefly when this happens. Loops can be
+  resumed individually with a single press; if no loops are playing they start
+  immediately, otherwise they wait for the next bar. Exporting downloads each
+  loop with its BPM in the file name. Use `V` for the video looper.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   immediately, otherwise they wait for the next bar. Exporting downloads each
   loop with its BPM in the file name. Use `V` for the video looper. Hold Option
   and press **Cmd+R** to erase **all** loops. Use Cmd+R/S/D/F individually to
-  erase loops A–D or Cmd+V for the video loop.
+  erase loops A–D or Cmd+V for the video loop. Each looper button shows a small
+  progress bar divided into four segments so you can see the current bar and how
+  far through the loop you are in real time.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   Cmd+R/S/D/F individually to erase loops A–D or Cmd+V for the video loop. Each
   looper button now has a compact progress bar tucked beneath it with four tick
 marks showing the current bar, and the button itself pulses in time while
-recording. Loopers A–C use cyan, magenta and yellow bars, while Looper D uses a
-brighter orange line that’s slightly thicker (1.4px) for better visibility.
+recording. Loopers A–C use cyan, magenta and yellow bars, while Looper D uses
+orange. All four progress bars are a bright 1.4 px thick for better visibility.
 Hold the mapped **MIDI Shift** note while pressing any loop note to erase that
 loop instantly. The progress bars speed up or slow down when loops are pitched
 so the visuals stay in sync.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   Set up to 10 visual cue points on any YouTube video. Use keyboard shortcuts or drag & drop markers.
 
 - 🔁 **Audio & Video Loopers**
-  Record loops in sync with video or audio. Press `R` to record or overdub,
-  hold **Option** while pressing `R` to add another audio loop (up to 4 at once).
-  Use `V` for the video looper. Double press either key to erase.
+  Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
+  up to four separate audio loops. Double press a loop key to erase. Use `V` for
+  the video looper.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -94,7 +94,7 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Action | Key |
 |-------|-----|
 | Set/Jump to Cue | Ctrl/Cmd + [1–0] |
-| Audio Looper | R (Option+R adds new loop) |
+| Audio Loopers | R / S / D / F |
 | Video Looper | V |
 | EQ Toggle | E |
 | Compressor Toggle | C |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 Mark cue points, loop audio/video, apply live effects, and customize your beatmaking experience on YouTube.
 
 The **YouTube Beatmaker Cues** extension supports precise pitch adjustments, audio and video looping, effects toggling, and intuitive cue management. Use keyboard shortcuts or the detailed Advanced Panel for quick control.
+## New in 1.4
+* Four independent audio loopers with bright progress bars beneath each button
+* Each bar shows four tick marks so you can follow the beat
+* Progress bars are a uniform 1.4 px thick for clarity
+* Export downloads every active loop as its own track with BPM
+* Pitching loops renames files with `-pitched-<BPM>bpm`
+
 
 ## New in 1.3
 * Works inside the YouTube iframe on [Samplette.io](https://samplette.io) and other `youtube-nocookie.com` embeds, even when the referrer is hidden. The toolbar becomes scrollable and MIDI features are disabled there.

--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   selected loop—the button blinks briefly when this happens. Loops can be
   resumed individually with a single press; if no loops are playing they start
   immediately, otherwise they wait for the next bar. Exporting downloads each
-  loop with its BPM in the file name. Use `V` for the video looper. Hold Option
-  and press **Cmd+R** to erase **all** loops. Use Cmd+R/S/D/F individually to
-  erase loops A–D or Cmd+V for the video loop. Each looper button now has a
-compact progress bar tucked beneath it with four tick marks showing the current
-bar, and the button itself pulses in time while recording. Progress fills use
-bright CMYK colors (cyan, magenta, yellow, black) so each loop stands out.
+  active loop as its own track with the BPM rounded in the file name. If loops
+  are pitched, the filenames also include `-pitched-<BPM>bpm`. Use `V` for the
+  video looper. Hold Option and press **Cmd+R** to erase **all** loops. Use
+  Cmd+R/S/D/F individually to erase loops A–D or Cmd+V for the video loop. Each
+  looper button now has a compact progress bar tucked beneath it with four tick
+marks showing the current bar, and the button itself pulses in time while
+recording. Loopers A–C use cyan, magenta and yellow bars, while Looper D uses a
+brighter orange line that’s slightly thicker (1.4px) for better visibility.
 Hold the mapped **MIDI Shift** note while pressing any loop note to erase that
 loop instantly. The progress bars speed up or slow down when loops are pitched
 so the visuals stay in sync.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
 - 🔁 **Audio & Video Loopers**
   Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
   up to four separate audio loops. The first loop sets the tempo automatically;
-  additional loops stay synced to that BPM. Double press a loop key to erase.
-  Exporting downloads each loop with its BPM in the file name. Use `V` for the
-  video looper.
+  additional loops stay synced to that BPM. Double press a loop key to stop the
+  loops. Hold that second press a moment longer (or tap three times quickly) to
+  erase the selected loop. Exporting downloads each loop with its BPM in the
+  file name. Use `V` for the video looper.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
 - 🔁 **Audio & Video Loopers**
   Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
   up to four separate audio loops. The first loop sets the tempo automatically;
-  additional loops stay synced to that BPM. Double press a loop key to stop the
+  additional loops stay synced to that BPM. Recording a new loop while others
+  play adds it seamlessly without restarting. Double press a loop key to stop the
   loops after the current bar finishes. Hold that second press a moment longer
   (or tap three times quickly) to erase the selected loop—the button blinks
   briefly when this happens. If no loops are currently playing, new recordings

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   selected loop—the button blinks briefly when this happens. Loops can be
   resumed individually with a single press; if no loops are playing they start
   immediately, otherwise they wait for the next bar. Exporting downloads each
-  loop with its BPM in the file name. Use `V` for the video looper. Press
-  **Cmd+R** any time to erase all audio loops at once.
+  loop with its BPM in the file name. Use `V` for the video looper. Hold Option
+  and press **Cmd+R** to erase **all** loops. Use Cmd+R/S/D/F individually to
+  erase loops A–D or Cmd+V for the video loop.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -111,7 +112,12 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Reverb Toggle | Q |
 | Cassette Toggle | W |
 | Undo / Redo | U / Cmd+U |
-| Erase All Loops | Cmd+R |
+| Erase Loop A | Cmd+R |
+| Erase Loop B | Cmd+S |
+| Erase Loop C | Cmd+D |
+| Erase Loop D | Cmd+F |
+| Erase All Loops | Cmd+Option+R |
+| Erase Video Loop | Cmd+V |
 | Export | Ctrl/Cmd + Enter |
 | Pitch Down / Up | `,` / `.` |
 | Random Cue | `-` |

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   immediately, otherwise they wait for the next bar. Exporting downloads each
   loop with its BPM in the file name. Use `V` for the video looper. Hold Option
   and press **Cmd+R** to erase **all** loops. Use Cmd+R/S/D/F individually to
-  erase loops A–D or Cmd+V for the video loop. Each looper button displays a
-  bright progress bar under the button with four tick marks showing the current
-  bar. Hold the mapped **MIDI Shift** note while pressing any loop note to erase
-  that loop instantly.
+  erase loops A–D or Cmd+V for the video loop. Each looper button now has a
+  compact progress bar tucked beneath it with four tick marks showing the current
+  bar, and the button itself pulses in time while recording. Hold the mapped
+  **MIDI Shift** note while pressing any loop note to erase that loop instantly.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
 - 🎯 **Cue Points**  
   Set up to 10 visual cue points on any YouTube video. Use keyboard shortcuts or drag & drop markers.
 
-- 🔁 **Audio & Video Loopers**  
-  Record loops in sync with video or audio (shortcuts: `R` for audio, `V` for video). Double press to erase.
+- 🔁 **Audio & Video Loopers**
+  Record loops in sync with video or audio. Press `R` to record or overdub,
+  hold **Option** while pressing `R` to add another audio loop (up to 4 at once).
+  Use `V` for the video looper. Double press either key to erase.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -92,7 +94,7 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Action | Key |
 |-------|-----|
 | Set/Jump to Cue | Ctrl/Cmd + [1–0] |
-| Audio Looper | R |
+| Audio Looper | R (Option+R adds new loop) |
 | Video Looper | V |
 | EQ Toggle | E |
 | Compressor Toggle | C |

--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ compact progress bar tucked beneath it with four tick marks showing the current
 bar, and the button itself pulses in time while recording. Progress fills use
 bright CMYK colors (cyan, magenta, yellow, black) so each loop stands out.
 Hold the mapped **MIDI Shift** note while pressing any loop note to erase that
-loop instantly.
+loop instantly. The progress bars speed up or slow down when loops are pitched
+so the visuals stay in sync.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback. When targeting loops,
   the pitch slider adjusts all four audio loopers together and exported files
   include the modified pitch. If loops are pitched when exporting, each file
   name ends with `-pitched-<BPM>bpm` where `<BPM>` reflects the new tempo.
+  Export uses offline rendering for reliability.
 
 - 🎛️ **Live Effects**  
   Toggle EQ (`E`), Compressor (`C`), Reverb (`Q`), and Cassette (`W`) in real time.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ loop instantly.
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback. When targeting loops,
   the pitch slider adjusts all four audio loopers together and exported files
-  include the modified pitch.
+  include the modified pitch. If loops are pitched when exporting, each file
+  name ends with `-pitched-<BPM>bpm` where `<BPM>` reflects the new tempo.
 
 - 🎛️ **Live Effects**  
   Toggle EQ (`E`), Compressor (`C`), Reverb (`Q`), and Cassette (`W`) in real time.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   additional loops stay synced to that BPM. Double press a loop key to erase.
   Exporting downloads each loop with its BPM in the file name. Use `V` for the
   video looper.
+  Press `P` to pause or resume all loops.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -103,6 +104,7 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Reverb Toggle | Q |
 | Cassette Toggle | W |
 | Undo / Redo | U / Cmd+U |
+| Pause Loops | P |
 | Export | Ctrl/Cmd + Enter |
 | Pitch Down / Up | `,` / `.` |
 | Random Cue | `-` |

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
 
 - 🔁 **Audio & Video Loopers**
   Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
-  up to four separate audio loops. Double press a loop key to erase. Use `V` for
-  the video looper.
+  up to four separate audio loops. The first loop sets the tempo automatically;
+  additional loops stay synced to that BPM. Double press a loop key to erase.
+  Exporting downloads each loop with its BPM in the file name. Use `V` for the
+  video looper.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -68,7 +70,7 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   Manage built-in and imported samples (kick, hihat, snare), randomize or load packs on demand.
 
 - 🎹 **MIDI Support**
-  Use your MIDI controller to trigger actions. Custom mappings available via UI.
+  Use your MIDI controller to trigger actions. Custom mappings are available via UI, including key and MIDI assignments for all four loopers.
 
 - 🔄 **Super Knob**
   Select any cue via pad, keyboard, or MIDI note and twist the mapped knob to
@@ -106,6 +108,8 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Random Cue | `-` |
 | Blind Mode | B |
 | Show Advanced Panel | A |
+
+All loop keys and MIDI notes can be reassigned in the Key Mapping and MIDI Mapping windows.
 
 ## Touch Sequencer
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Hold the mapped **MIDI Shift** note while pressing any loop note to erase that
 loop instantly.
 
 - 🎚️ **Pitch Control**  
-  Independent pitch control for video and loop playback.
+  Independent pitch control for video and loop playback. When targeting loops,
+  the pitch slider adjusts all four audio loopers together and exported files
+  include the modified pitch.
 
 - 🎛️ **Live Effects**  
   Toggle EQ (`E`), Compressor (`C`), Reverb (`Q`), and Cassette (`W`) in real time.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
   up to four separate audio loops. The first loop sets the tempo automatically;
   additional loops stay synced to that BPM. Double press a loop key to stop the
-  loops. Hold that second press a moment longer (or tap three times quickly) to
-  erase the selected loop. Exporting downloads each loop with its BPM in the
-  file name. Use `V` for the video looper.
+  loops after the current bar finishes. Hold that second press a moment longer
+  (or tap three times quickly) to erase the selected loop. Single pressing while
+  stopped resumes playback on the next bar. Exporting downloads each loop with
+  its BPM in the file name. Use `V` for the video looper.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   immediately, otherwise they wait for the next bar. Exporting downloads each
   loop with its BPM in the file name. Use `V` for the video looper. Hold Option
   and press **Cmd+R** to erase **all** loops. Use Cmd+R/S/D/F individually to
-  erase loops A–D or Cmd+V for the video loop. Each looper button shows a small
-  progress bar divided into four segments so you can see the current bar and how
-  far through the loop you are in real time.
+  erase loops A–D or Cmd+V for the video loop. Each looper button displays a
+  bright progress bar under the button with four tick marks showing the current
+  bar. Hold the mapped **MIDI Shift** note while pressing any loop note to erase
+  that loop instantly.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.
@@ -127,6 +128,7 @@ To create the downloadable archive yourself, run `bash build_release.sh`. The sc
 | Show Advanced Panel | A |
 
 All loop keys and MIDI notes can be reassigned in the Key Mapping and MIDI Mapping windows.
+Holding the MIDI Shift note while pressing a loop note erases that loop.
 
 ## Touch Sequencer
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,15 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
   Record loops in sync with video or audio. Use `R`, `S`, `D`, or `F` to control
   up to four separate audio loops. The first loop sets the tempo automatically;
   additional loops stay synced to that BPM. Recording a new loop while others
-  play adds it seamlessly without restarting. Double press a loop key to stop the
-  loops after the current bar finishes. Hold that second press a moment longer
-  (or tap three times quickly) to erase the selected loop—the button blinks
-  briefly when this happens. If no loops are currently playing, new recordings
-  start immediately; otherwise they wait for the next bar. Single presses while
-  stopped resume playback on the next bar. Exporting downloads each loop with
-  its BPM in the file name. Use `V` for the video looper.
+  play adds it seamlessly without restarting. Loops keep the exact length you
+  recorded—automatic trimming has been removed to avoid cutting short sounds.
+  Double press a loop key to stop the loops after the current bar finishes. Hold
+  that second press a moment longer (or tap three times quickly) to erase the
+  selected loop—the button blinks briefly when this happens. If no loops are
+  currently playing, new recordings start immediately; otherwise they wait for
+  the next bar. Single presses while stopped resume playback on the next bar.
+  Exporting downloads each loop with its BPM in the file name. Use `V` for the
+  video looper.
 
 - 🎚️ **Pitch Control**  
   Independent pitch control for video and loop playback.

--- a/content.js
+++ b/content.js
@@ -6047,9 +6047,9 @@ function updatePitch(v) {
     }
   } else {
     // pitchTarget === "loop"
-    if (loopSource) {
-      loopSource.playbackRate.value = rate;
-    }
+    loopSources.forEach((src, i) => {
+      if (src) src.playbackRate.value = rate * (audioLoopRates[i] || 1);
+    });
     // Keep the main video at normal speed
     if (videoPreviewElement) videoPreviewElement.playbackRate = 1;
     const mv = getVideoElement();

--- a/content.js
+++ b/content.js
@@ -2459,7 +2459,7 @@ async function ensureAudioContext() {
   if (!audioContext) {
     // Create the main AudioContext with minimal latency for responsive pads
     audioContext = new (window.AudioContext || window.webkitAudioContext)({
-      latencyHint: 0, // lowest possible latency
+      latencyHint: "interactive", // lowest possible latency
       sampleRate: 48000
     });
     setupAudioNodes();
@@ -3704,7 +3704,7 @@ function startVideoRecording() {
     console.error("Video recording error:", err);
     alert("Video recording failed!");
   };
-  videoMediaRecorder.start();
+  videoMediaRecorder.start(100);
 
   videoLooperState = "recording";
   updateVideoLooperButtonColor();
@@ -5190,10 +5190,7 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     });
   });
   const pWrap = document.createElement('div');
-  pWrap.style.position = 'absolute';
-  pWrap.style.left = '2px';
-  pWrap.style.right = '2px';
-  pWrap.style.bottom = '2px';
+  pWrap.style.marginTop = '2px';
   pWrap.style.height = '6px';
   pWrap.style.background = '#222';
   pWrap.style.pointerEvents = 'none';
@@ -5213,7 +5210,7 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     f.style.bottom = '0';
     f.style.width = '0%';
     f.style.opacity = 0;
-    f.style.background = ['#f44','#4f4','#44f','#ff4'][i % 4];
+    f.style.background = ['#0ff','#f0f','#ff0','#fa0'][i % 4];
     b.appendChild(f);
     for (let j=1;j<4;j++){
       const di=document.createElement('div');
@@ -5230,8 +5227,8 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     pWrap.appendChild(b);
     loopProgressFillsMin[i] = f;
   }
-  loopBtnMin.appendChild(pWrap);
   minimalUIContainer.appendChild(loopBtnMin);
+  minimalUIContainer.appendChild(pWrap);
 
   let exportBtnMin = document.createElement("button");
   exportBtnMin.className = "looper-btn";
@@ -5470,10 +5467,7 @@ function addControls() {
   unifiedLooperButton.addEventListener("mouseup", onLooperButtonMouseUp);
 
   const progressWrap = document.createElement("div");
-  progressWrap.style.position = "absolute";
-  progressWrap.style.left = "2px";
-  progressWrap.style.right = "2px";
-  progressWrap.style.bottom = "2px";
+  progressWrap.style.marginTop = "2px";
   progressWrap.style.height = "8px";
   progressWrap.style.pointerEvents = "none";
   progressWrap.style.background = "#222";
@@ -5492,7 +5486,7 @@ function addControls() {
     fill.style.left = '0';
     fill.style.width = '0%';
     fill.style.opacity = 0;
-    fill.style.background = ['#f44','#4f4','#44f','#ff4'][i % 4];
+    fill.style.background = ['#0ff','#f0f','#ff0','#fa0'][i % 4];
     barBg.appendChild(fill);
     for (let j = 1; j < 4; j++) {
       const ind = document.createElement('div');
@@ -5509,8 +5503,8 @@ function addControls() {
     progressWrap.appendChild(barBg);
     loopProgressFills[i] = fill;
   }
-  unifiedLooperButton.appendChild(progressWrap);
   looperButtonRow.appendChild(unifiedLooperButton);
+  looperButtonRow.appendChild(progressWrap);
 
   videoLooperButton = document.createElement("button");
   videoLooperButton.className = "looper-btn";
@@ -6141,10 +6135,42 @@ function handleMIDIMessage(e) {
     if (note === midiNotes.kick) playSample("kick");
     if (note === midiNotes.hihat) playSample("hihat");
     if (note === midiNotes.snare) playSample("snare");
-    if (note === midiNotes.looperA) { activeLoopIndex = 0; if (looperState !== "idle" && !audioLoopBuffers[0]) recordingNewLoop = true; onLooperButtonMouseDown(); }
-    if (note === midiNotes.looperB) { activeLoopIndex = 1; if (looperState !== "idle" && !audioLoopBuffers[1]) recordingNewLoop = true; onLooperButtonMouseDown(); }
-    if (note === midiNotes.looperC) { activeLoopIndex = 2; if (looperState !== "idle" && !audioLoopBuffers[2]) recordingNewLoop = true; onLooperButtonMouseDown(); }
-    if (note === midiNotes.looperD) { activeLoopIndex = 3; if (looperState !== "idle" && !audioLoopBuffers[3]) recordingNewLoop = true; onLooperButtonMouseDown(); }
+    if (note === midiNotes.looperA) {
+      activeLoopIndex = 0;
+      if (isModPressed) {
+        eraseAudioLoopAt(0);
+      } else {
+        if (looperState !== "idle" && !audioLoopBuffers[0]) recordingNewLoop = true;
+        onLooperButtonMouseDown();
+      }
+    }
+    if (note === midiNotes.looperB) {
+      activeLoopIndex = 1;
+      if (isModPressed) {
+        eraseAudioLoopAt(1);
+      } else {
+        if (looperState !== "idle" && !audioLoopBuffers[1]) recordingNewLoop = true;
+        onLooperButtonMouseDown();
+      }
+    }
+    if (note === midiNotes.looperC) {
+      activeLoopIndex = 2;
+      if (isModPressed) {
+        eraseAudioLoopAt(2);
+      } else {
+        if (looperState !== "idle" && !audioLoopBuffers[2]) recordingNewLoop = true;
+        onLooperButtonMouseDown();
+      }
+    }
+    if (note === midiNotes.looperD) {
+      activeLoopIndex = 3;
+      if (isModPressed) {
+        eraseAudioLoopAt(3);
+      } else {
+        if (looperState !== "idle" && !audioLoopBuffers[3]) recordingNewLoop = true;
+        onLooperButtonMouseDown();
+      }
+    }
     if (note === midiNotes.undo) onUndoButtonMouseDown();
     if (note === midiNotes.videoLooper) onVideoLooperButtonMouseDown();
     if (note === midiNotes.eqToggle) toggleEQFilter();
@@ -6177,10 +6203,10 @@ function handleMIDIMessage(e) {
   } else if (st === 128) {
     if (note === midiNotes.pitchDown) stopPitchDownRepeat();
     if (note === midiNotes.pitchUp) stopPitchUpRepeat();
-    if (note === midiNotes.looperA) { activeLoopIndex = 0; onLooperButtonMouseUp(); }
-    if (note === midiNotes.looperB) { activeLoopIndex = 1; onLooperButtonMouseUp(); }
-    if (note === midiNotes.looperC) { activeLoopIndex = 2; onLooperButtonMouseUp(); }
-    if (note === midiNotes.looperD) { activeLoopIndex = 3; onLooperButtonMouseUp(); }
+    if (note === midiNotes.looperA) { activeLoopIndex = 0; if (!isModPressed) onLooperButtonMouseUp(); }
+    if (note === midiNotes.looperB) { activeLoopIndex = 1; if (!isModPressed) onLooperButtonMouseUp(); }
+    if (note === midiNotes.looperC) { activeLoopIndex = 2; if (!isModPressed) onLooperButtonMouseUp(); }
+    if (note === midiNotes.looperD) { activeLoopIndex = 3; if (!isModPressed) onLooperButtonMouseUp(); }
     // if (note === midiNotes.undo) onUndoButtonMouseUp();
     if (note === midiNotes.videoLooper) onVideoLooperButtonMouseUp();
   }

--- a/content.js
+++ b/content.js
@@ -678,6 +678,7 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
             compMode = "off";
 
   const BUILTIN_DEFAULT_COUNT = 10;
+  const MAX_AUDIO_LOOPS = 4; // limit simultaneous audio loops
   // Speed level 1 matches the old fastest rate. Levels 2 and 3 are
   // progressively quicker for rapid cue movement.
   const superKnobSpeedMap = { 1: 0.12, 2: 0.25, 3: 0.5 };
@@ -1949,6 +1950,9 @@ function finalizeLoopBuffer(buf) {
 
   pushUndoState();
   if (recordingNewLoop || audioLoopBuffers.length === 0) {
+    if (audioLoopBuffers.length >= MAX_AUDIO_LOOPS) {
+      audioLoopBuffers.shift();
+    }
     audioLoopBuffers.push(buf);
     recordingNewLoop = false;
   } else {
@@ -4261,7 +4265,7 @@ function isTypingInTextField(e) {
  * Keyboard & Sample Triggers
  **************************************/
 function onKeyDown(e) {
-  if (e.key === "Shift") {
+  if (e.key === "Alt") {
     isShiftKeyDown = true;
     return;
   }
@@ -4408,7 +4412,7 @@ function onKeyDown(e) {
 }
 
 function onKeyUp(e) {
-  if (e.key === "Shift") {
+  if (e.key === "Alt") {
     isShiftKeyDown = false;
     return;
   }
@@ -4519,7 +4523,7 @@ function onLooperButtonMouseUp() {
 }
 
 function singlePressAudioLooperAction() {
-  if (isShiftKeyDown) {
+  if (isShiftKeyDown || isModPressed) {
     recordingNewLoop = true;
     startRecording();
   } else if (looperState === "idle") {

--- a/content.js
+++ b/content.js
@@ -4474,10 +4474,10 @@ function onKeyDown(e) {
   const loopKeys = [extensionKeys.looperA, extensionKeys.looperB, extensionKeys.looperC, extensionKeys.looperD];
   for (let i = 0; i < loopKeys.length; i++) {
     if (k === loopKeys[i].toLowerCase()) {
-      if (e.repeat) return; // ignore key repeat so hold detection works
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
+      if (e.repeat) return; // ignore repeat but still consume the event
       activeLoopIndex = i;
       if (looperState !== "idle" && !audioLoopBuffers[i]) recordingNewLoop = true;
       onLooperButtonMouseDown();
@@ -4485,6 +4485,9 @@ function onKeyDown(e) {
     }
   }
   if (k === extensionKeys.videoLooper.toLowerCase()) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
     if (e.repeat) return;
     onVideoLooperButtonMouseDown();
     return;

--- a/content.js
+++ b/content.js
@@ -475,6 +475,7 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
   * Global Variables
   **************************************/
   const MAX_AUDIO_LOOPS = 4; // limit simultaneous audio loops
+  const LOOP_COLORS = ['#0ff', '#f0f', '#ff0', '#fa0'];
   let cuePoints = {},
       sampleKeys = { kick: "é", hihat: "à", snare: "$" },
       // Additional extension-wide keystrokes that can be rebound:
@@ -5222,7 +5223,7 @@ container.insertBefore(minimalUIContainer, container.firstChild);
   for (let i = 0; i < MAX_AUDIO_LOOPS; i++) {
     const b = document.createElement('div');
     b.style.position = 'relative';
-    b.style.height = '1px';
+    b.style.height = i === 3 ? '1.4px' : '1px';
     b.style.background = '#333';
     const f = document.createElement('div');
     f.style.position = 'absolute';
@@ -5232,7 +5233,7 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     f.style.bottom = '0';
     f.style.width = '0%';
     f.style.opacity = 0;
-    f.style.background = ['#0ff','#f0f','#ff0','#000'][i % 4];
+    f.style.background = LOOP_COLORS[i % 4];
     b.appendChild(f);
     for (let j=1;j<4;j++){
       const di=document.createElement('div');
@@ -5521,7 +5522,7 @@ function addControls() {
   for (let i = 0; i < MAX_AUDIO_LOOPS; i++) {
     const barBg = document.createElement('div');
     barBg.style.position = 'relative';
-    barBg.style.height = '2px';
+    barBg.style.height = i === 3 ? '1.4px' : '2px';
     barBg.style.background = '#333';
     const fill = document.createElement('div');
     fill.style.position = 'absolute';
@@ -5530,7 +5531,7 @@ function addControls() {
     fill.style.left = '0';
     fill.style.width = '0%';
     fill.style.opacity = 0;
-    fill.style.background = ['#0ff','#f0f','#ff0','#000'][i % 4];
+    fill.style.background = LOOP_COLORS[i % 4];
     barBg.appendChild(fill);
     for (let j = 1; j < 4; j++) {
       const ind = document.createElement('div');

--- a/content.js
+++ b/content.js
@@ -2211,6 +2211,16 @@ function updateVideoLooperButtonColor() {
   else if (videoLooperState === "playing") c = "green";
   videoLooperButton.style.backgroundColor = (videoLooperState === "idle") ? "grey" : c;
 }
+
+function blinkButton(element, updateFn, color = "magenta", duration = 150) {
+  if (!element) return;
+  const prev = element.style.backgroundColor;
+  element.style.backgroundColor = color;
+  setTimeout(() => {
+    if (typeof updateFn === "function") updateFn();
+    else element.style.backgroundColor = prev;
+  }, duration);
+}
 function updateExportButtonColor() {
   if (!exportButton) return;
   if (videoLooperState !== "idle" && videoPreviewURL) {
@@ -3435,6 +3445,7 @@ function eraseAudioLoop() {
   }
   updateExportButtonColor();
   updateLooperButtonColor();
+  blinkButton(unifiedLooperButton, updateLooperButtonColor);
   if (window.refreshMinimalState) window.refreshMinimalState();
 }
 
@@ -3508,6 +3519,7 @@ function eraseVideoLoop() {
     videoPreviewURL = null;
   }
   updateVideoLooperButtonColor();
+  blinkButton(videoLooperButton, updateVideoLooperButtonColor);
   updateExportButtonColor();
   if (window.refreshMinimalState) window.refreshMinimalState();
 }
@@ -4447,6 +4459,7 @@ function onKeyDown(e) {
   const loopKeys = [extensionKeys.looperA, extensionKeys.looperB, extensionKeys.looperC, extensionKeys.looperD];
   for (let i = 0; i < loopKeys.length; i++) {
     if (k === loopKeys[i].toLowerCase()) {
+      if (e.repeat) return; // ignore key repeat so hold detection works
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
@@ -4457,6 +4470,7 @@ function onKeyDown(e) {
     }
   }
   if (k === extensionKeys.videoLooper.toLowerCase()) {
+    if (e.repeat) return;
     onVideoLooperButtonMouseDown();
     return;
   }

--- a/content.js
+++ b/content.js
@@ -4368,6 +4368,7 @@ function onKeyDown(e) {
   if (k === extensionKeys.compressor.toLowerCase()) {
     e.preventDefault();
     e.stopPropagation();
+    e.stopImmediatePropagation();
     toggleCompressor();
     return;
   }
@@ -4380,6 +4381,9 @@ function onKeyDown(e) {
   const loopKeys = [extensionKeys.looperA, extensionKeys.looperB, extensionKeys.looperC, extensionKeys.looperD];
   for (let i = 0; i < loopKeys.length; i++) {
     if (k === loopKeys[i].toLowerCase()) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
       activeLoopIndex = i;
       if (looperState !== "idle" && !audioLoopBuffers[i]) recordingNewLoop = true;
       onLooperButtonMouseDown();
@@ -4448,6 +4452,9 @@ function onKeyUp(e) {
   const loopKeys = [extensionKeys.looperA, extensionKeys.looperB, extensionKeys.looperC, extensionKeys.looperD];
   for (let i = 0; i < loopKeys.length; i++) {
     if (k === loopKeys[i].toLowerCase()) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
       activeLoopIndex = i;
       onLooperButtonMouseUp();
     }
@@ -4457,8 +4464,8 @@ function onKeyUp(e) {
   }
   // Remove the undo handling here because it's handled in onKeyDown.
 }
-addTrackedListener(document, "keydown", onKeyDown);
-addTrackedListener(document, "keyup", onKeyUp);
+addTrackedListener(document, "keydown", onKeyDown, true);
+addTrackedListener(document, "keyup", onKeyUp, true);
 
 function playSample(n) {
   ensureAudioContext().then(() => {

--- a/content.js
+++ b/content.js
@@ -5211,9 +5211,11 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     });
   });
   const pWrap = document.createElement('div');
-  pWrap.style.marginTop = '2px';
+  pWrap.style.position = 'absolute';
+  pWrap.style.left = '0';
+  pWrap.style.right = '0';
+  pWrap.style.bottom = '-6px';
   pWrap.style.height = '6px';
-  pWrap.style.width = '100%';
   pWrap.style.background = '#222';
   pWrap.style.pointerEvents = 'none';
   pWrap.style.display = 'flex';
@@ -5232,7 +5234,7 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     f.style.bottom = '0';
     f.style.width = '0%';
     f.style.opacity = 0;
-    f.style.background = ['#0ff','#f0f','#ff0','#fa0'][i % 4];
+    f.style.background = ['#0ff','#f0f','#ff0','#000'][i % 4];
     b.appendChild(f);
     for (let j=1;j<4;j++){
       const di=document.createElement('div');
@@ -5250,7 +5252,10 @@ container.insertBefore(minimalUIContainer, container.firstChild);
     loopProgressFillsMin[i] = f;
   }
   const loopWrapMin = document.createElement('div');
+  loopWrapMin.style.position = 'relative';
   loopWrapMin.style.display = 'flex';
+  loopWrapMin.style.overflow = 'visible';
+  loopWrapMin.style.paddingBottom = '0';
   loopWrapMin.style.flexDirection = 'column';
   loopWrapMin.style.alignItems = 'stretch';
   loopWrapMin.appendChild(loopBtnMin);
@@ -5505,9 +5510,11 @@ function addControls() {
   unifiedLooperButton.appendChild(looperPulseEl);
 
   const progressWrap = document.createElement("div");
-  progressWrap.style.marginTop = "2px";
+  progressWrap.style.position = "absolute";
+  progressWrap.style.left = "0";
+  progressWrap.style.right = "0";
+  progressWrap.style.bottom = "-8px";
   progressWrap.style.height = "8px";
-  progressWrap.style.width = '100%';
   progressWrap.style.pointerEvents = "none";
   progressWrap.style.background = "#222";
   progressWrap.style.display = "flex";
@@ -5525,7 +5532,7 @@ function addControls() {
     fill.style.left = '0';
     fill.style.width = '0%';
     fill.style.opacity = 0;
-    fill.style.background = ['#0ff','#f0f','#ff0','#fa0'][i % 4];
+    fill.style.background = ['#0ff','#f0f','#ff0','#000'][i % 4];
     barBg.appendChild(fill);
     for (let j = 1; j < 4; j++) {
       const ind = document.createElement('div');
@@ -5543,7 +5550,9 @@ function addControls() {
     loopProgressFills[i] = fill;
   }
   const unifiedWrap = document.createElement('div');
+  unifiedWrap.style.position = 'relative';
   unifiedWrap.style.display = 'flex';
+  unifiedWrap.style.overflow = 'visible';
   unifiedWrap.style.flexDirection = 'column';
   unifiedWrap.style.alignItems = 'stretch';
   unifiedWrap.appendChild(unifiedLooperButton);

--- a/content.js
+++ b/content.js
@@ -2223,11 +2223,13 @@ function loopProgressStep() {
   loopProgressRAF = requestAnimationFrame(loopProgressStep);
   if (!audioContext || !baseLoopDuration) return;
   const now = audioContext.currentTime;
-  const progress = (now - loopStartAbsoluteTime) % baseLoopDuration;
+  let elapsed = now - loopStartAbsoluteTime;
+  if (elapsed < 0) elapsed = 0;
+  const progress = elapsed % baseLoopDuration;
   const pct = (progress / baseLoopDuration) * 100;
   const bar = Math.floor((progress / baseLoopDuration) * 4);
   const beatDur = baseLoopDuration / 4;
-  const beatProg = (now - loopStartAbsoluteTime) % beatDur;
+  const beatProg = elapsed % beatDur;
   const pulse = 1 - (beatProg / beatDur);
   for (let i = 0; i < MAX_AUDIO_LOOPS; i++) {
     const active = loopPlaying[i] || (looperState !== "idle" && activeLoopIndex === i);
@@ -3374,6 +3376,8 @@ function playSingleLoop(index, startOffset = 0, startTime = null) {
     if (!startTime && baseLoopDuration)
       startOffset = (audioContext.currentTime - loopStartAbsoluteTime) % baseLoopDuration;
     src.start(when, startOffset);
+    if (!loopSource)
+      loopStartAbsoluteTime = when - startOffset;
     loopSources[index] = src;
     loopPlaying[index] = true;
     if (!loopSource) loopSource = src;

--- a/content.js
+++ b/content.js
@@ -3476,6 +3476,13 @@ function eraseAudioLoop() {
   if (window.refreshMinimalState) window.refreshMinimalState();
 }
 
+function eraseAudioLoopAt(index) {
+  const prev = activeLoopIndex;
+  activeLoopIndex = index;
+  eraseAudioLoop();
+  activeLoopIndex = prev;
+}
+
 function eraseAllAudioLoops() {
   if (audioLoopBuffers.some(b => b)) pushUndoState();
   clearOverdubTimers();
@@ -4431,12 +4438,49 @@ function onKeyDown(e) {
 
   const k = e.key.toLowerCase();
 
-  // Cmd+R erases all audio loops
-  if (e.metaKey && k === extensionKeys.looperA.toLowerCase()) {
+  // Option+Cmd+R erases all audio loops
+  if (e.metaKey && e.altKey && k === extensionKeys.looperA.toLowerCase()) {
     e.preventDefault();
     e.stopPropagation();
     e.stopImmediatePropagation();
     eraseAllAudioLoops();
+    return;
+  }
+  // Cmd+V erases the video loop
+  if (e.metaKey && k === extensionKeys.videoLooper.toLowerCase()) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    eraseVideoLoop();
+    return;
+  }
+  // Cmd+R/S/D/F erase loops A–D
+  if (e.metaKey && k === extensionKeys.looperA.toLowerCase()) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    eraseAudioLoopAt(0);
+    return;
+  }
+  if (e.metaKey && k === extensionKeys.looperB.toLowerCase()) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    eraseAudioLoopAt(1);
+    return;
+  }
+  if (e.metaKey && k === extensionKeys.looperC.toLowerCase()) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    eraseAudioLoopAt(2);
+    return;
+  }
+  if (e.metaKey && k === extensionKeys.looperD.toLowerCase()) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    eraseAudioLoopAt(3);
     return;
   }
   

--- a/content.js
+++ b/content.js
@@ -4887,13 +4887,16 @@ function exportLoop() {
       const loops = audioLoopBuffers.map((b, i) => ({ buf: b, idx: i })).filter(o => o.buf);
       if (!loops.length) return;
       const rBase = (pitchTarget === "loop") ? getCurrentPitchRate() : 1;
+      const pitched = Math.abs(rBase - 1) > 0.001;
       let bpm = loopsBPM ? loopsBPM : (baseLoopDuration ? Math.round((60 * 4) / baseLoopDuration) : 0);
       loops.forEach(({buf, idx}) => {
-        let rate = rBase * (audioLoopRates[idx] || 1);
-        const name = `loop${String.fromCharCode(65 + idx)}${bpm ? "-" + bpm + "bpm" : ""}.wav`;
+        const rate = rBase * (audioLoopRates[idx] || 1);
+        const outBpm = pitched && bpm ? Math.round(bpm * rBase) : bpm;
+        const base = `loop${String.fromCharCode(65 + idx)}`;
+        const name = `${base}${pitched ? "-pitched" : ""}${outBpm ? "-" + outBpm + "bpm" : ""}.wav`;
         if (Math.abs(rate - 1) < 0.01) {
-          let wav = encodeWAV(buf);
-          let url = URL.createObjectURL(wav);
+          const wav = encodeWAV(buf);
+          const url = URL.createObjectURL(wav);
           let a = document.createElement("a");
           a.style.display = "none";
           a.href = url;

--- a/content.js
+++ b/content.js
@@ -472,8 +472,9 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
     if (outputDeviceSelect) outputDeviceSelect.value = id;
   }
   /**************************************
-   * Global Variables
-   **************************************/
+  * Global Variables
+  **************************************/
+  const MAX_AUDIO_LOOPS = 4; // limit simultaneous audio loops
   let cuePoints = {},
       sampleKeys = { kick: "é", hihat: "à", snare: "$" },
       // Additional extension-wide keystrokes that can be rebound:
@@ -688,7 +689,6 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
             compMode = "off";
 
   const BUILTIN_DEFAULT_COUNT = 10;
-  const MAX_AUDIO_LOOPS = 4; // limit simultaneous audio loops
   // Speed level 1 matches the old fastest rate. Levels 2 and 3 are
   // progressively quicker for rapid cue movement.
   const superKnobSpeedMap = { 1: 0.12, 2: 0.25, 3: 0.5 };

--- a/content.js
+++ b/content.js
@@ -4628,7 +4628,12 @@ function singlePressAudioLooperAction() {
   } else if (looperState === "recording") {
     stopRecordingAndPlay();
   } else {
-    toggleOverdub();
+    if (!audioLoopBuffers[activeLoopIndex]) {
+      recordingNewLoop = true;
+      startRecording();
+    } else {
+      toggleOverdub();
+    }
   }
 }
 

--- a/content.js
+++ b/content.js
@@ -2034,6 +2034,10 @@ function captureAppState() {
 }
 
 function restoreAppState(st) {
+  stopAllLoopSources();
+  pendingStopTimeouts.forEach((t, i) => { if (t) clearTimeout(t); pendingStopTimeouts[i] = null; });
+  if (newLoopStartTimeout) { clearTimeout(newLoopStartTimeout); newLoopStartTimeout = null; }
+
   loopBuffer = st.loopBuffer;
   looperState = st.looperState;
   audioLoopBuffers = st.audioLoopBuffers.slice();
@@ -2096,7 +2100,7 @@ function restoreAppState(st) {
   } else if (looperState === "recording") {
     looperState = "idle";
   } else {
-    stopLoop();
+    looperState = "idle";
   }
 
   if (window.refreshMinimalState) {
@@ -5223,7 +5227,7 @@ container.insertBefore(minimalUIContainer, container.firstChild);
   for (let i = 0; i < MAX_AUDIO_LOOPS; i++) {
     const b = document.createElement('div');
     b.style.position = 'relative';
-    b.style.height = i === 3 ? '1.4px' : '1px';
+    b.style.height = '1.4px';
     b.style.background = '#333';
     const f = document.createElement('div');
     f.style.position = 'absolute';
@@ -5522,7 +5526,7 @@ function addControls() {
   for (let i = 0; i < MAX_AUDIO_LOOPS; i++) {
     const barBg = document.createElement('div');
     barBg.style.position = 'relative';
-    barBg.style.height = i === 3 ? '1.4px' : '2px';
+    barBg.style.height = '1.4px';
     barBg.style.background = '#333';
     const fill = document.createElement('div');
     fill.style.position = 'absolute';

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Beatmaker Extension",
-  "version": "1.2",
+  "version": "1.4",
   "description": "Mark cue points, play drum sounds, and customize your experience on YouTube.",
   "permissions": ["storage", "activeTab", "scripting", "unlimitedStorage"],
   "host_permissions": [


### PR DESCRIPTION
## Summary
- add arrays to store multiple audio loops
- allow shift+R to start a new loop
- play all stored loops together
- improve MIME selection for video recorder

## Testing
- `node --check content.js`
- `bash build_release.sh`

------
https://chatgpt.com/codex/tasks/task_e_685464a4a6888327a3047377f2f983c6