### PR TITLE
Add Kaoss Pad FX controller

### DIFF
--- a/content.js
+++ b/content.js
@@ -3121,13 +3121,6 @@ async function setupAudioNodes() {
   bus2Gain.connect(masterGain);
   bus3Gain.connect(masterGain);
 
-  masterGain.connect(fxPadMasterIn);
-  if (fxPadActive && fxPadEngine) {
-    fxPadMasterIn.connect(fxPadEngine.nodeIn);
-    fxPadEngine.nodeOut.connect(fxPadMasterOut);
-  } else {
-    fxPadMasterIn.connect(fxPadMasterOut);
-  }
   bus4Gain.connect(masterGain);
 
   eqFilterNode = audioContext.createBiquadFilter();
@@ -3507,6 +3500,9 @@ async function setupFxPadNodes() {
  * Single function to apply all FX routing
  **************************************/
 function applyAllFXRouting() {
+  if (!audioContext) return;
+  if (!fxPadMasterIn) fxPadMasterIn = audioContext.createGain();
+  if (!fxPadMasterOut) fxPadMasterOut = audioContext.createGain();
   // First, disconnect everything that may have been connected:
   videoGain.disconnect();
   if (antiClickGain) antiClickGain.disconnect();
@@ -3587,6 +3583,14 @@ function applyAllFXRouting() {
   bus1Gain.connect(masterGain);
   bus2Gain.connect(masterGain);
   bus3Gain.connect(masterGain);
+
+  masterGain.connect(fxPadMasterIn);
+  if (fxPadActive && fxPadEngine) {
+    fxPadMasterIn.connect(fxPadEngine.nodeIn);
+    fxPadEngine.nodeOut.connect(fxPadMasterOut);
+  } else {
+    fxPadMasterIn.connect(fxPadMasterOut);
+  }
 
   // -------------------------------------------
   // COMPRESSOR BYPASS LOGIC FOR BUS4:

--- a/content.js
+++ b/content.js
@@ -9014,10 +9014,12 @@ function toggleFxPadDragOnly(){
     fxPadDragOnlyBtn.style.background = fxPadDragOnly ? '#555' : '#0a0';
   }
   if(fxPadDragOnly && !fxPadDragging && fxPadEngine){
-    fxPadBall.x = 0.5;
-    fxPadBall.y = 0.5;
+    if(!fxPadSticky){
+      fxPadBall.x = 0.5;
+      fxPadBall.y = 0.5;
+      drawFxPadBall();
+    }
     fxPadEngine.triggerCorner(0.5,0.5,false);
-    drawFxPadBall();
   }
 }
 

--- a/content.js
+++ b/content.js
@@ -8906,6 +8906,12 @@ function buildFxPadWindow() {
     fxPadDropdowns[i]=sel; wrap.appendChild(sel);
   }
 
+  // Ensure dropdowns reflect the engine defaults on first build
+  const defaults=['stutterGrain','delay','flanger','reverb'];
+  defaults.forEach((t,idx)=>{
+    if(fxPadDropdowns[idx]) fxPadDropdowns[idx].value=t;
+  });
+
 
   fxPadModeBtn = document.createElement('button');
   fxPadModeBtn.className = 'looper-btn';

--- a/content.js
+++ b/content.js
@@ -762,7 +762,6 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
       fxPadCanvas = null,
       fxPadDragHandle = null,
       fxPadDropdowns = [],
-      fxPadStickyBtn = null,
       fxPadModeBtn = null,
       fxPadDragOnlyBtn = null,
       fxPadMultiMode = false,
@@ -8885,21 +8884,14 @@ function buildFxPadWindow() {
     fxPadDropdowns[i]=sel; wrap.appendChild(sel);
   }
 
-  fxPadStickyBtn = document.createElement('button');
-  fxPadStickyBtn.className = 'looper-btn';
-  fxPadStickyBtn.textContent = fxPadSticky ? 'Active On' : 'Active Off';
-  fxPadStickyBtn.style.position = 'absolute';
-  fxPadStickyBtn.style.left = '4px';
-  fxPadStickyBtn.style.bottom = '4px';
-  fxPadStickyBtn.addEventListener('click',toggleFxPadSticky);
-  wrap.appendChild(fxPadStickyBtn);
-
   fxPadDragOnlyBtn = document.createElement('button');
   fxPadDragOnlyBtn.className = 'looper-btn';
-  fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag On' : 'On Drag Off';
+  fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag' : 'Active';
   fxPadDragOnlyBtn.style.position = 'absolute';
-  fxPadDragOnlyBtn.style.left = '70px';
+  fxPadDragOnlyBtn.style.left = '4px';
   fxPadDragOnlyBtn.style.bottom = '4px';
+  fxPadDragOnlyBtn.style.background = fxPadDragOnly ? '#555' : '#0a0';
+  fxPadDragOnlyBtn.style.color = '#fff';
   fxPadDragOnlyBtn.addEventListener('click',toggleFxPadDragOnly);
   wrap.appendChild(fxPadDragOnlyBtn);
 
@@ -8997,13 +8989,15 @@ async function handleFxPadJoystick(x, y) {
 
 function toggleFxPadSticky(){
   fxPadSticky = !fxPadSticky;
-  if (fxPadStickyBtn) fxPadStickyBtn.textContent = fxPadSticky ? 'Active On' : 'Active Off';
   drawFxPadBall();
 }
 
 function toggleFxPadDragOnly(){
   fxPadDragOnly = !fxPadDragOnly;
-  if (fxPadDragOnlyBtn) fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag On' : 'On Drag Off';
+  if (fxPadDragOnlyBtn){
+    fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag' : 'Active';
+    fxPadDragOnlyBtn.style.background = fxPadDragOnly ? '#555' : '#0a0';
+  }
   if(fxPadDragOnly && !fxPadDragging && fxPadEngine){
     fxPadBall.x = 0.5;
     fxPadBall.y = 0.5;

--- a/content.js
+++ b/content.js
@@ -8887,7 +8887,7 @@ function buildFxPadWindow() {
 
   fxPadStickyBtn = document.createElement('button');
   fxPadStickyBtn.className = 'looper-btn';
-  fxPadStickyBtn.textContent = fxPadSticky ? 'Stick On' : 'Stick Off';
+  fxPadStickyBtn.textContent = fxPadSticky ? 'Active On' : 'Active Off';
   fxPadStickyBtn.style.position = 'absolute';
   fxPadStickyBtn.style.left = '4px';
   fxPadStickyBtn.style.bottom = '4px';
@@ -8896,7 +8896,7 @@ function buildFxPadWindow() {
 
   fxPadDragOnlyBtn = document.createElement('button');
   fxPadDragOnlyBtn.className = 'looper-btn';
-  fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag' : 'Always';
+  fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag On' : 'On Drag Off';
   fxPadDragOnlyBtn.style.position = 'absolute';
   fxPadDragOnlyBtn.style.left = '70px';
   fxPadDragOnlyBtn.style.bottom = '4px';
@@ -8972,7 +8972,7 @@ function startFxPadAnim(){
     }
     drawFxPadBall();
     if(fxPadActive && fxPadTriggerCorner){
-      if(fxPadDragOnly && !fxPadDragging && !fxPadSticky){
+      if(fxPadDragOnly && !fxPadDragging){
         fxPadTriggerCorner(0.5,0.5,false);
       }else{
         fxPadTriggerCorner(fxPadBall.x,fxPadBall.y,fxPadSticky);
@@ -8997,14 +8997,14 @@ async function handleFxPadJoystick(x, y) {
 
 function toggleFxPadSticky(){
   fxPadSticky = !fxPadSticky;
-  if (fxPadStickyBtn) fxPadStickyBtn.textContent = fxPadSticky ? 'Stick On' : 'Stick Off';
+  if (fxPadStickyBtn) fxPadStickyBtn.textContent = fxPadSticky ? 'Active On' : 'Active Off';
   drawFxPadBall();
 }
 
 function toggleFxPadDragOnly(){
   fxPadDragOnly = !fxPadDragOnly;
-  if (fxPadDragOnlyBtn) fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag' : 'Always';
-  if(fxPadDragOnly && !fxPadDragging && !fxPadSticky && fxPadEngine){
+  if (fxPadDragOnlyBtn) fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag On' : 'On Drag Off';
+  if(fxPadDragOnly && !fxPadDragging && fxPadEngine){
     fxPadBall.x = 0.5;
     fxPadBall.y = 0.5;
     fxPadEngine.triggerCorner(0.5,0.5,false);
@@ -9063,7 +9063,7 @@ addTrackedListener(document,'pointermove',e=>{if(fxPadDragging) handleFxPadPoint
 addTrackedListener(document,'pointerup',()=>{
   fxPadDragging=false;
   fxPadBall.vx=0; fxPadBall.vy=0;
-  if(fxPadActive && fxPadDragOnly && !fxPadSticky && fxPadTriggerCorner){
+  if(fxPadActive && fxPadDragOnly && fxPadTriggerCorner){
     fxPadTriggerCorner(0.5,0.5,false);
   }
 });

--- a/content.js
+++ b/content.js
@@ -3785,14 +3785,19 @@ async function createBpmLooperEffect(ctx){
   const mix = ctx.createGain();
   input.connect(node).connect(mix);
   const rate = ctx.sampleRate;
+  let currentLen = 0;
   return {
     in: input,
     out: mix,
     update(x,y){
       const beat = 60 / (typeof sequencerBPM === 'number' ? sequencerBPM : 120);
-      const beats = 0.25 + 3.75 * y; // 1/4 to 4 beats
-      const len = Math.floor(rate * beat * beats);
-      node.port.postMessage({loop: true, length: len});
+      const step = Math.min(4, Math.round(y * 4));
+      const beatLen = [0.25,0.5,1,2,4][step];
+      const len = Math.floor(rate * beat * beatLen);
+      if(len !== currentLen){
+        currentLen = len;
+        node.port.postMessage({loop: true, length: len});
+      }
       mix.gain.value = x;
     }
   };
@@ -3830,6 +3835,8 @@ async function createFxPadEngine(ctx){
     else if(type==='flanger') e=createFlangerEffect(ctx);
     else if(type==='phaser') e=await createPhaserEffect(ctx);
     else if(type==='tremoloPan') e=createTremoloPanEffect(ctx);
+    else if(type==='autopan') e=createAutopanEffect(ctx);
+    else if(type==='beatRepeat') e=await createBeatRepeatEffect(ctx);
     else if(type==='distortion') e=createDistortionEffect(ctx,2);
     else if(type==='overdrive') e=createDistortionEffect(ctx,4);
     else if(type==='fuzz') e=createDistortionEffect(ctx,8);
@@ -3847,6 +3854,20 @@ async function createFxPadEngine(ctx){
     else if(type==='centerCancel') e=createCenterCancelEffect(ctx);
     else if(type==='subsonic') e=createSubsonicEffect(ctx);
     else if(type==='bpmLooper') e=await createBpmLooperEffect(ctx);
+    else if(type==='vinylBreak') e=await createVinylBreakEffect(ctx);
+    else if(type==='duckComp') e=createDuckCompEffect(ctx);
+    else if(type==='echoBreak') e=createEchoBreakEffect(ctx);
+    else if(type==='oneShotDelay') e=createOneShotDelayEffect(ctx);
+    else if(type==='stutterGrain') e=await createStutterGrainEffect(ctx);
+    else if(type==='freezeLooper') e=createFreezeLooperEffect(ctx);
+    else if(type==='jagFilter') e=createJagFilterEffect(ctx);
+    else if(type==='bitDecimator') e=await createBitDecimatorEffect(ctx);
+    else if(type==='loopBreaker') e=await createLoopBreakerEffect(ctx);
+    else if(type==='resonator') e=createResonatorEffect(ctx);
+    else if(type==='reverbBreak') e=createReverbBreakEffect(ctx);
+    else if(type==='pitchUp') e=await createPitchUpEffect(ctx);
+    else if(type==='flangerJet') e=createFlangerJetEffect(ctx);
+    else if(type==='phaserSweep') e=await createPhaserSweepEffect(ctx);
     if(e){ nodeIn.connect(e.in); e.out.connect(wetGains[i]); effects[i]=e; wetGains[i].gain.setTargetAtTime(0,ctx.currentTime,0.04); }
   }
   function triggerCorner(x,y,held){
@@ -8841,10 +8862,12 @@ function buildFxPadWindow() {
 
   const types = [
     'filterDrive','pitch','delay','isolator','vinylSim','reverb','tapeEcho','chorus',
-    'flanger','phaser','tremoloPan','distortion','overdrive','fuzz','wah','octave',
+    'flanger','phaser','tremoloPan','autopan','beatRepeat','distortion','overdrive','fuzz','wah','octave',
     'compressor','equalizer','bitCrash','noiseGen','radioTuning',
     'slicerFlanger','ringMod','chromPitchShift','pitchFine','centerCancel',
-    'subsonic','bpmLooper'
+    'subsonic','bpmLooper','vinylBreak','duckComp','echoBreak','oneShotDelay',
+    'stutterGrain','freezeLooper','jagFilter','bitDecimator','loopBreaker',
+    'resonator','reverbBreak','pitchUp','flangerJet','phaserSweep'
   ];
   for (let i=0;i<4;i++) {
     const sel=document.createElement('select');

--- a/content.js
+++ b/content.js
@@ -9029,11 +9029,12 @@ function toggleFxPadMode(){
 
 function deactivateFxPad(){
   fxPadActive = false;
-  fxPadSticky = false;
-  fxPadBall.x = 0.5;
-  fxPadBall.y = 0.5;
   if (fxPadEngine) fxPadEngine.triggerCorner(0.5,0.5,false);
   cancelAnimationFrame(fxPadAnimId);
+  if(!fxPadSticky){
+    fxPadBall.x = 0.5;
+    fxPadBall.y = 0.5;
+  }
   drawFxPadBall();
   applyAllFXRouting();
 }

--- a/content.js
+++ b/content.js
@@ -763,7 +763,6 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
       fxPadDragHandle = null,
       fxPadDropdowns = [],
       fxPadModeBtn = null,
-      fxPadDragOnlyBtn = null,
       fxPadMultiMode = false,
       fxPadAnimId = 0,
       fxPadPrev = {x:0,y:0},
@@ -777,7 +776,6 @@ if (typeof randomCuesButton !== "undefined" && randomCuesButton) {
       fxPadActive = false,
       fxPadBall = {x:0.5,y:0.5,vx:0,vy:0},
       fxPadSticky = false,
-      fxPadDragOnly = false,
       fxPadDragging = false;
       deckA = null,
       deckB = null,
@@ -8908,16 +8906,6 @@ function buildFxPadWindow() {
     fxPadDropdowns[i]=sel; wrap.appendChild(sel);
   }
 
-  fxPadDragOnlyBtn = document.createElement('button');
-  fxPadDragOnlyBtn.className = 'looper-btn';
-  fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag' : 'Active';
-  fxPadDragOnlyBtn.style.position = 'absolute';
-  fxPadDragOnlyBtn.style.left = '4px';
-  fxPadDragOnlyBtn.style.bottom = '4px';
-  fxPadDragOnlyBtn.style.background = fxPadDragOnly ? '#555' : '#0a0';
-  fxPadDragOnlyBtn.style.color = '#fff';
-  fxPadDragOnlyBtn.addEventListener('click',toggleFxPadDragOnly);
-  wrap.appendChild(fxPadDragOnlyBtn);
 
   fxPadModeBtn = document.createElement('button');
   fxPadModeBtn.className = 'looper-btn';
@@ -8975,24 +8963,15 @@ function startFxPadAnim(){
   cancelAnimationFrame(fxPadAnimId);
   const step=()=>{
     if(!fxPadDragging && !fxPadSticky){
-      if(fxPadDragOnly){
-        fxPadBall.x = 0.5;
-        fxPadBall.y = 0.5;
-      }else{
-        fxPadBall.x += (0.5 - fxPadBall.x) * 0.2;
-        fxPadBall.y += (0.5 - fxPadBall.y) * 0.2;
-        if(Math.abs(fxPadBall.x-0.5)<0.001) fxPadBall.x=0.5;
-        if(Math.abs(fxPadBall.y-0.5)<0.001) fxPadBall.y=0.5;
-      }
+      fxPadBall.x += (0.5 - fxPadBall.x) * 0.2;
+      fxPadBall.y += (0.5 - fxPadBall.y) * 0.2;
+      if(Math.abs(fxPadBall.x-0.5)<0.001) fxPadBall.x=0.5;
+      if(Math.abs(fxPadBall.y-0.5)<0.001) fxPadBall.y=0.5;
       fxPadBall.vx = fxPadBall.vy = 0;
     }
     drawFxPadBall();
     if(fxPadActive && fxPadTriggerCorner){
-      if(fxPadDragOnly && !fxPadDragging){
-        fxPadTriggerCorner(0.5,0.5,false);
-      }else{
-        fxPadTriggerCorner(fxPadBall.x,fxPadBall.y,fxPadSticky);
-      }
+      fxPadTriggerCorner(fxPadBall.x,fxPadBall.y,fxPadSticky);
     }
     fxPadAnimId=requestAnimationFrame(step);
   };
@@ -9016,21 +8995,6 @@ function toggleFxPadSticky(){
   drawFxPadBall();
 }
 
-function toggleFxPadDragOnly(){
-  fxPadDragOnly = !fxPadDragOnly;
-  if (fxPadDragOnlyBtn){
-    fxPadDragOnlyBtn.textContent = fxPadDragOnly ? 'On Drag' : 'Active';
-    fxPadDragOnlyBtn.style.background = fxPadDragOnly ? '#555' : '#0a0';
-  }
-  if(fxPadDragOnly && !fxPadDragging && fxPadEngine){
-    if(!fxPadSticky){
-      fxPadBall.x = 0.5;
-      fxPadBall.y = 0.5;
-      drawFxPadBall();
-    }
-    fxPadEngine.triggerCorner(0.5,0.5,false);
-  }
-}
 
 function toggleFxPadMode(){
   fxPadMultiMode = !fxPadMultiMode;
@@ -9083,9 +9047,6 @@ addTrackedListener(document,'pointermove',e=>{if(fxPadDragging) handleFxPadPoint
 addTrackedListener(document,'pointerup',()=>{
   fxPadDragging=false;
   fxPadBall.vx=0; fxPadBall.vy=0;
-  if(fxPadActive && fxPadDragOnly && fxPadTriggerCorner){
-    fxPadTriggerCorner(0.5,0.5,false);
-  }
 });
 
 /* ------------------------------------------------------

--- a/content.js
+++ b/content.js
@@ -3456,7 +3456,16 @@ async function createVinylBreakEffect(ctx){
 }
 
 async function createStutterEffect(ctx){
-  const node=await createStutterNode(ctx); return {in:node,out:node,update(x,y,held){ node.port.postMessage({loop:held,length:Math.floor(2048*(0.2+y*0.8))}); }};
+  const node=await createStutterNode(ctx);
+  const rate = ctx.sampleRate;
+  return {
+    in: node,
+    out: node,
+    update(x,y,held){
+      const len = Math.floor(rate * (0.1 + 0.4 * y));
+      node.port.postMessage({loop: held, length: len});
+    }
+  };
 }
 
 async function createBeatRepeatEffect(ctx){
@@ -3464,7 +3473,16 @@ async function createBeatRepeatEffect(ctx){
   const node = await createStutterNode(ctx);
   const mix = ctx.createGain();
   input.connect(node).connect(mix);
-  return {in:input, out:mix, update(x,y){node.port.postMessage({loop:true,length:Math.floor(2048*(0.05+0.45*y))}); mix.gain.value=x;}};
+  const rate = ctx.sampleRate;
+  return {
+    in: input,
+    out: mix,
+    update(x,y){
+      const len = Math.floor(rate * (0.05 + 0.45 * y));
+      node.port.postMessage({loop: true, length: len});
+      mix.gain.value = x;
+    }
+  };
 }
 
 async function createPhaserEffect(ctx){


### PR DESCRIPTION
## Summary
- introduce fxPad key and MIDI mapping
- insert Kaoss Pad engine with multiple effects
- inject FX pad popup and routing nodes
- hook up keyboard and MIDI handlers for the pad
- rebuild audio routing with FX pad chain

## Testing
- `bash build_release.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862f2fe23008327b42d9c0f7b1b1ddb