### PR TITLE
feat: add shift double-tap playback control

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Samples and cue points persist between sessions. Easily export loops, manage cue
 - 🎹 **MIDI Support**
   Use your MIDI controller to trigger actions. Custom mappings are available via UI, including key and MIDI assignments for all four loopers.
 
+- ⏯️ **Shift Play/Pause**
+  Quick-tap the Shift key (or mapped MIDI Shift note) to play when paused.
+  Double-tap Shift while playing to pause the video, and holding Shift still acts as a modifier for other controls.
+
 - 🔄 **Super Knob**
   Select any cue via pad, keyboard, or MIDI note and twist the mapped knob to
   slide its position left or right. Endless encoders currently act like normal


### PR DESCRIPTION
## Summary
- allow quick Shift taps to play the video
- allow Shift double-tap (keyboard or MIDI) to pause playback
- document Shift play/pause behavior in README

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_68935139b7108327ab2791b4a6e7312e